### PR TITLE
docs: conflict definitions and wordsmith

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -64,20 +64,18 @@ Modifying Postgres source code is non-trivial work and the changes are unlikely 
 
 ### On Detecting Conflicts
 
-During our initial study on Postgres extensions, we identified and categorized extension conflicts into three types:
+During our initial study on Postgres extensions, we identified and categorized extension incompatibilities into three types:
 
-* **Hook Conflict:** 
-Installing two extensions using the same hook causes unintended functionality changes compared to installing alone.
-* **Behavior Conflict:** 
-<!-- TODO(team):  A little confused on what behavior conflict is -->
-* **Installation Conflict:** 
-An extension cannot be successfully installed to Postgres due to some internal/external dependencies.
+#### Installation Conflict
 
-To detect hook conflicts, we can generate SQLs that covers code path of the extension based on the existing test cases for the extension. If extensions behave differently in different environments with the same set of SQL queires, then they cannot exist at the same time. This type of conflict is possible to be automatically detected by extending tools like [SQLSmith](https://github.com/anse1/sqlsmith) and [Squrriel](https://github.com/s3team/Squirrel).
+This is the case where an extension cannot be successfully installed to Postgres due to some internal/external dependencies. One example of installation conflict is that some extensions include Postgres source code, and therefore its correctness relies on whether it is being compiled and installed to the same Postgres version. The installer can take care of it.
 
-To detect behavior conflicts, we will have to manually review all extensions. For example, pg_hint_plan includes some parts of pg_stat_statements source code to ensure the plan hints (part of the SQL comments) are properly stored in the statistics table.
+#### Erroneous Results
+This is the case where two extensions can be installed together but doing so results in crashing the program or producing erroneous results because they are using a same hook. To detect incompatibility associated with erroneous results, we can generate SQLs that covers code path of the extension based on the existing test cases for the extension. If extensions behave differently in different environments with the same set of SQL queires, then they cannot exist at the same time. This type of conflict is possible to be automatically detected by extending tools like [SQLSmith](https://github.com/anse1/sqlsmith) and [Squrriel](https://github.com/s3team/Squirrel).
 
-One example of installation conflict is that some extensions include Postgres source code, and therefore its correctness relies on whether it is being compiled and installed to the same Postgres version. The installer can take care of it.
+#### Unintented Behavior
+This is the case where two extensions are technically compatible with each other but doing so results in having unexpected results because they are using a same hook. For example, pg_hint_plan includes some parts of pg_stat_statements source code to ensure the plan hints (part of the SQL comments) are properly stored in the statistics table. To detect incompatibility associated with unintented behavior, we can first apply the same strategy as for erroneous results, but then we will have to manually review all extensions to determine which category they belong.
+
 
 ## Testing Plan
 


### PR DESCRIPTION
I mainly edited the detecting conflict section. One TODO remaining is defining behavior conflict which I don't fully understand. The other two types (hook conflict and installation conflict) seems to have straightforward definitions.

- [x] **TODO**(team): define behavior conflict.