### PR TITLE
docs: fix subcommand naming and add documentation

### DIFF
--- a/pgext-cli/src/cmd_init.rs
+++ b/pgext-cli/src/cmd_init.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use crate::config::WorkspaceConfig;
 use crate::CmdInit;
 
+/// Initialze the workspace
 pub fn cmd_init(cmd: CmdInit) -> Result<()> {
   println!("pg_config: {}", cmd.pg_config);
   println!("pg_data: {}", cmd.pg_data);
@@ -21,6 +22,7 @@ pub fn cmd_init(cmd: CmdInit) -> Result<()> {
     pg_data: cmd.pg_data,
     pg_contrib: cmd.pg_contrib,
   };
+  // saving config
   std::fs::write(
     PathBuf::from("pgextworkdir").join("config.toml"),
     toml::to_string_pretty(&config)?,

--- a/pgext-cli/src/cmd_install.rs
+++ b/pgext-cli/src/cmd_install.rs
@@ -9,6 +9,7 @@ use crate::config::load_workspace_config;
 use crate::plugin::load_plugin_db;
 use crate::{CmdInstall, CmdInstallAll};
 
+/// Create work directory if not exists
 pub fn create_workdir() -> Result<PathBuf> {
   std::fs::create_dir_all("pgextworkdir")?;
   std::fs::create_dir_all("pgextworkdir/downloads")?;
@@ -16,6 +17,7 @@ pub fn create_workdir() -> Result<PathBuf> {
   Ok(PathBuf::new().join("pgextworkdir"))
 }
 
+/// Install all extensions
 pub fn cmd_install_all(cmd: CmdInstallAll) -> Result<()> {
   let db = load_plugin_db()?;
   let mut failed = vec![];
@@ -40,6 +42,7 @@ pub fn cmd_install_all(cmd: CmdInstallAll) -> Result<()> {
   Ok(())
 }
 
+/// Install an extension
 pub fn cmd_install(cmd: CmdInstall) -> Result<()> {
   let db = load_plugin_db()?;
   let workdir = create_workdir()?;
@@ -111,6 +114,7 @@ pub fn cmd_install(cmd: CmdInstall) -> Result<()> {
   }
 }
 
+/// Install `pgx_show_hooks` and `pgx_trace_hooks`
 pub fn cmd_install_hook() -> Result<()> {
   let config = load_workspace_config()?;
 

--- a/pgext-cli/src/cmd_list.rs
+++ b/pgext-cli/src/cmd_list.rs
@@ -3,6 +3,7 @@ use console::style;
 
 use crate::plugin::load_plugin_db;
 
+/// List all extensions in `plugindb`
 pub fn cmd_list() -> Result<()> {
   let db = load_plugin_db()?;
   for plugin in db.plugins {

--- a/pgext-cli/src/cmd_test.rs
+++ b/pgext-cli/src/cmd_test.rs
@@ -16,6 +16,7 @@ use crate::resolve_pgxs::pgxs_installcheck;
 use crate::test_control::{pgx_start_pg15, pgx_stop_pg15, ExtTestControl};
 use crate::{CmdDemo, CmdTest, CmdTestAll, CmdTestSingle};
 
+/// Run the `demo` subcommand
 pub fn cmd_demo(cmd: CmdDemo) -> Result<()> {
   let db = load_plugin_db()?;
   let last = find_plugin(&db, &cmd.name)?;
@@ -96,6 +97,7 @@ pub fn cmd_demo(cmd: CmdDemo) -> Result<()> {
   Ok(())
 }
 
+/// Run the `test-all` subcommand
 pub fn cmd_test_all(cmd: CmdTestAll) -> Result<()> {
   let db = load_plugin_db()?;
   let mut failed = vec![];
@@ -191,6 +193,7 @@ pub fn cmd_test_all(cmd: CmdTestAll) -> Result<()> {
   Ok(())
 }
 
+/// Run the `test` subcommand
 pub fn cmd_test(cmd: CmdTest, pbar: Option<ProgressBar>) -> Result<Vec<String>> {
   let custom_sql = if cmd.run_custom_sql {
     Some(std::fs::read_to_string("custom.sql")?)
@@ -315,6 +318,7 @@ pub fn cmd_test(cmd: CmdTest, pbar: Option<ProgressBar>) -> Result<Vec<String>> 
   Ok(hooks)
 }
 
+/// Run the `test-single` subcommand
 pub fn cmd_test_single(cmd: CmdTestSingle, pbar: Option<ProgressBar>) -> Result<Vec<String>> {
   let db = load_plugin_db()?;
   let config = load_workspace_config()?;

--- a/pgext-cli/src/config.rs
+++ b/pgext-cli/src/config.rs
@@ -13,12 +13,14 @@ pub struct WorkspaceConfig {
   pub pg_contrib: String,
 }
 
+/// Load the workspace config
 pub fn load_workspace_config() -> Result<WorkspaceConfig> {
   let config = std::fs::read_to_string(PathBuf::from("pgextworkdir").join("config.toml"))
     .context("cannot find workspace config, did you run init?")?;
   Ok(toml::from_str(&config)?)
 }
 
+/// Edit `postgresql.conf` preload libraries list
 pub fn edit_pgconf(db: &PluginDb, config: &WorkspaceConfig, plugins: &[Plugin]) -> Result<Vec<String>> {
   let conf = PathBuf::from(&config.pg_data).join("postgresql.conf");
   let pgconf = std::fs::read_to_string(&conf)?;

--- a/pgext-cli/src/download.rs
+++ b/pgext-cli/src/download.rs
@@ -6,6 +6,7 @@ use duct::cmd;
 
 use crate::plugin::GitDownload;
 
+/// Download and uncompress a zip file
 pub fn download_zip(zip_url: String, download_path: &Path, build_dir: &Path, verbose: bool) -> Result<()> {
   if download_path.exists() {
     println!("{} {}", style("Skipping Download").bold().blue(), zip_url);
@@ -33,6 +34,7 @@ pub fn download_zip(zip_url: String, download_path: &Path, build_dir: &Path, ver
   Ok(())
 }
 
+/// Download an uncompress a tar file
 pub fn download_tar(tar_url: String, download_path: &Path, build_dir: &Path, verbose: bool) -> Result<()> {
   if download_path.exists() {
     println!("{} {}", style("Skipping Download").bold().blue(), tar_url);

--- a/pgext-cli/src/main.rs
+++ b/pgext-cli/src/main.rs
@@ -10,7 +10,7 @@ mod test_control;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
-/// PgExt - A PostgresSQL extension installer tool
+/// PgExtMgrExt - A PostgresSQL Extension Manager As an Extension
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
@@ -31,7 +31,7 @@ enum Commands {
   Demo(CmdDemo),
 }
 
-/// Demo
+/// Repeatedly run one extension's unit test while installing all other extensions one by one
 #[derive(Parser, Debug)]
 pub struct CmdDemo {
   /// The name of the extension (in `plugindb.toml`)
@@ -75,12 +75,12 @@ pub struct CmdInstallAll {
 #[derive(Parser, Debug)]
 pub struct CmdList {}
 
-/// Install extension
+/// Test one extension
 #[derive(Parser, Debug)]
 pub struct CmdTestSingle {
   /// The name of the extension (in `plugindb.toml`)
   name: String,
-  /// Run installchecks
+  /// Run extension unit tests
   #[clap(long)]
   check: bool,
 }
@@ -90,7 +90,7 @@ pub struct CmdTestSingle {
 pub struct CmdTest {
   /// extension names in plugindb
   exts: Vec<String>,
-  /// Run installchecks
+  /// Run last extension's unit tests after installing all extensions
   #[clap(long)]
   check_last: bool,
   /// Run custom SQLs after installing all extensions
@@ -98,12 +98,13 @@ pub struct CmdTest {
   run_custom_sql: bool,
 }
 
-/// Install all extensions in plugindb
+/// Test all extensions in plugindb individually
 #[derive(Parser, Debug)]
 pub struct CmdTestAll {
   /// Dump data to file
   #[clap(long)]
   dump_to: Option<String>,
+  /// Run extension unit tests
   #[clap(long)]
   check: bool,
 }

--- a/pgext-cli/src/plugin.rs
+++ b/pgext-cli/src/plugin.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 
+/// Git download metadata
 #[derive(Deserialize, Clone)]
 pub struct GitDownload {
   pub url: String,
@@ -72,12 +73,14 @@ pub struct PluginDb {
   pub plugins: Vec<Plugin>,
 }
 
+/// Loads `plugindb` from file
 pub fn load_plugin_db() -> Result<PluginDb> {
   let plugindb = std::fs::read_to_string("plugindb.toml").context("Failed to open plugindb.toml")?;
   let plugindb: PluginDb = toml::from_str(&plugindb).context("Failed to parse plugindb.toml")?;
   Ok(plugindb)
 }
 
+/// Gets a plugin in `plugindb`
 pub fn find_plugin(db: &PluginDb, name: &str) -> Result<Plugin> {
   if let Some(plugin) = db.plugins.iter().find(|x| x.name == name) {
     Ok(plugin.clone())

--- a/pgext-cli/src/test_control.rs
+++ b/pgext-cli/src/test_control.rs
@@ -5,14 +5,23 @@ use postgres::{Client, NoTls};
 
 use crate::plugin::{InstallStrategy, Plugin};
 
+/// An extension test controller trait
 pub trait ExtTestControl {
+  /// Connect to an postgres database for testing
   fn connect_test_db() -> Result<Client>;
+  /// Handle extensions already installed in the database before testing
   fn handle_installed<F: Fn(String)>(&mut self, println: F) -> Result<()>;
+  /// Display `shared_preload_libraries`
   fn show_preload_libraries<F: Fn(String)>(&mut self, println: F) -> Result<()>;
+  /// Run `CREATE EXTENSION IF NOT EXISTS` for the plugin and its dependencies
   fn create_exns_for(&mut self, plugin: &Plugin) -> Result<()>;
+  /// Run `DROP EXTENSION` for the plugin and its dependencies
   fn drop_exns_for<F: Fn(String)>(&mut self, plugin: &Plugin, println: F) -> Result<()>;
+  /// Show all installed hooks
   fn show_hooks_all<F: Fn(String)>(&mut self, println: F) -> Result<Vec<String>>;
+  /// Create an extension if not exists
   fn create_exn_if_absent(&mut self, extname: &str) -> Result<u64>;
+  /// Drop an extension
   fn drop_exn(&mut self, extname: &str) -> Result<u64>;
 }
 
@@ -124,6 +133,7 @@ impl ExtTestControl for Client {
   }
 }
 
+/// Start the pgx-managed postgres 15 instance
 pub fn pgx_start_pg15() -> Result<()> {
   let output = cmd!("cargo", "pgx", "start", "pg15")
     .dir("pgx_show_hooks")
@@ -141,6 +151,7 @@ pub fn pgx_start_pg15() -> Result<()> {
   Ok(())
 }
 
+/// Stop the pgx-managed postgres 15 instance
 pub fn pgx_stop_pg15() -> Result<()> {
   cmd!("cargo", "pgx", "stop", "pg15")
     .dir("pgx_show_hooks")

--- a/plugindb.toml
+++ b/plugindb.toml
@@ -179,12 +179,12 @@ resolver = "pgxs"
 install_strategy = "preload+install"
 
 
-# [[plugins]]
-# name = "pgsentinel"
-# version = "fef77c8ae8061b22f12fc33872216eda5f10edc2"
-# download_git = { url = "https://github.com/pgsentinel/pgsentinel", rev = "fef77c8" }
-# resolver = "pgxs"
-# install_strategy = "preload+install"
+[[plugins]]
+name = "pgsentinel"
+version = "fef77c8ae8061b22f12fc33872216eda5f10edc2"
+download_git = { url = "https://github.com/pgsentinel/pgsentinel", rev = "fef77c8" }
+resolver = "pgxs"
+install_strategy = "preload+install"
 
 
 [[plugins]]


### PR DESCRIPTION
This PR fixes subcommand naming adds documentation to functions and structs. It also contains the demo subcommand at the status report.