### PR TITLE
fix: hooks lost when multiple exts installed

### DIFF
--- a/pgext_pg_poop/pgext_pg_poop.c
+++ b/pgext_pg_poop/pgext_pg_poop.c
@@ -28,7 +28,7 @@ static bool poopReceiveSlot(void *self, TupleTableSlot *slot, void *ctx,
     }
     bool isnull;
     Datum attr = slot_getattr(slot, i + 1, &isnull);
-    int64 vallen = toast_datum_size(attr);
+    int64 vallen = toast_raw_datum_size(attr) - VARHDRSZ;
 
     const char *poop_emoji = "\360\237\222\251";
     const int poop_emoji_len = 4;

--- a/pgextmgr/src/output_rewriter.rs
+++ b/pgextmgr/src/output_rewriter.rs
@@ -106,7 +106,6 @@ pub(crate) unsafe extern "C" fn before_executor_run(query_desc: *mut QueryDesc, 
     }
     rewriters.push(rewriter);
   }
-  pgrx::info!("rewriter!");
   if !rewriters.is_empty() {
     (*query_desc).dest =
       Box::leak(Box::new(OutputDest::new(rewriters, (*query_desc).dest))) as *mut _ as *mut DestReceiver;


### PR DESCRIPTION
Also fixed a bug that poop is not correctly computing the varchar size. Now we can get consistent result among `select '22'::VARCHAR;` and `select varcharcolumn from t;`