### PR TITLE
feat: support enable/disable extensions at runtime

### DIFF
--- a/pgextmgr/src/hook_mgr.rs
+++ b/pgextmgr/src/hook_mgr.rs
@@ -73,7 +73,7 @@ pub struct AllHooks {
   pub executor_run_hook: HookMgr<std::string::String, ExecutorRun_hook_type>,
   pub executor_finish_hook: HookMgr<std::string::String, ExecutorFinish_hook_type>,
   pub executor_end_hook: HookMgr<std::string::String, ExecutorEnd_hook_type>,
-  pub rewriters: Vec<(std::string::String, api::OutputRewriter)>,
+  pub rewriters: Vec<(std::string::String, api::OutputRewriter, bool)>,
 }
 
 impl AllHooks {

--- a/pgextmgr/src/output_rewriter.rs
+++ b/pgextmgr/src/output_rewriter.rs
@@ -98,13 +98,15 @@ impl OutputDest {
 
 pub(crate) unsafe extern "C" fn before_executor_run(query_desc: *mut QueryDesc, _: i32, _: u64, _: bool) {
   let mut rewriters: Vec<&'static OutputRewriter> = vec![];
-  for (_, rewriter) in &crate::ALL_HOOKS.rewriters {
-    if let Some(filter) = rewriter.filter {
-      if !filter(query_desc) {
-        continue;
+  for (_, rewriter, enabled) in &crate::ALL_HOOKS.rewriters {
+    if *enabled {
+      if let Some(filter) = rewriter.filter {
+        if !filter(query_desc) {
+          continue;
+        }
       }
+      rewriters.push(rewriter);
     }
-    rewriters.push(rewriter);
   }
   if !rewriters.is_empty() {
     (*query_desc).dest =


### PR DESCRIPTION
This PR add added the following functions to support enable/disable extensions at runtime. The users now have access to following functions:

```sql
 function pgextmgr.disable(text)
 function pgextmgr.disable_all()
 function pgextmgr.enable(text)
 function pgextmgr.enable_all()
```

All extensions are enabled by default.